### PR TITLE
 adapt the ElementDict class to handle scenarios where the XML child …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,3 +26,5 @@ v1.5,
  - Add support for changing tag aliases.
  - Fix problems with empty CDATA sections, e.g. empty structured text lines.
  - Switch internal XML handling to ElementTree.
+
+ adapt the ElementDict class to handle scenarios where the XML child elements don't have a unique attribute to use as a key for dictionary-like access

--- a/l5x/__init__.py
+++ b/l5x/__init__.py
@@ -1,1 +1,2 @@
+__version__ = "0.1.0 SE"
 from .project import (Project, InvalidFile)

--- a/l5x/project.py
+++ b/l5x/project.py
@@ -10,7 +10,7 @@ __get__() method. In this way the application can process L5X projects
 without worrying about low-level XML handling.
 """
 
-from .dom import (CDATA_TAG, ElementDict, AttributeDescriptor)
+from .dom import (CDATA_TAG, ElementDict, ElementIndexDict, AttributeDescriptor)
 from .module import (Module, SafetyNetworkNumber)
 from .tag import Scope
 import io
@@ -49,7 +49,8 @@ class Project(object):
         self.programs = ElementDict(progs, 'Name', Scope, value_args=[lang])
 
         mods = ctl_element.find('Modules')
-        self.modules = ElementDict(mods, 'Name', Module)
+        self.modules = ElementIndexDict(mods, Module)
+        # self.modules = ElementDict(mods, 'Name', Module)
 
     def parse(self, filename):
         """Parses the source project."""

--- a/l5x/tag.py
+++ b/l5x/tag.py
@@ -2,7 +2,7 @@
 Objects implementing tag access.
 """
 
-from l5x import dom
+from . import dom
 import copy
 import ctypes
 import itertools


### PR DESCRIPTION
…elements don't have a unique attribute to use as a key for dictionary-like access.